### PR TITLE
lock openspout to v4.28.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "illuminate/database": "^10.45|^11.0|^12.0",
         "illuminate/support": "^10.45|^11.0|^12.0",
         "league/csv": "^9.16",
-        "openspout/openspout": "^4.23",
+        "openspout/openspout": "4.28.5",
         "spatie/laravel-package-tools": "^1.9"
     },
     "autoload": {


### PR DESCRIPTION
Locked openspout to v4.28.5 because they dropped support for PHP 8.2 in the next release (v4.29.0)