### PR TITLE
Fix PrepareCsvExport.php

### DIFF
--- a/src/Exports/Jobs/PrepareCsvExport.php
+++ b/src/Exports/Jobs/PrepareCsvExport.php
@@ -75,7 +75,7 @@ class PrepareCsvExport implements ShouldQueue
             /** @var array<string, mixed> $originalBindings */
             $originalBindings = $query->getRawBindings();
 
-            if (! empty($originalOrders->all())) {
+            if (! empty($originalOrders->all()) && isset($originalOrders[0]['column'])) {
                 $query->reorder($originalOrders[0]['column'], $originalOrders[0]['direction']);
                 $originalOrders->forget(0);
             } else {


### PR DESCRIPTION
Fixing the issue in the PostgreSQL-specific query ordering logic where an empty $originalOrders array, or an element within the array lacking the 'column' key, was not handled correctly.